### PR TITLE
Revert "Bump langchain-openai from 0.1.23 to 0.2.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 langchain-couchbase==0.1.1
-langchain-openai==0.2.2
+langchain-openai==0.1.23
 pandas==2.2.3
 python-dotenv==1.0.1
 streamlit==1.38.0


### PR DESCRIPTION
Reverts couchbase-examples/hybrid-search-demo#36